### PR TITLE
fix: サイドバー幅を本家サイトのフレーム幅(10%)に合わせる

### DIFF
--- a/css/w3.css
+++ b/css/w3.css
@@ -53,7 +53,7 @@ hr{border:0;border-top:1px solid #eee;margin:20px 0}
 .w3-dropdown-hover:hover > .w3-button:first-child,.w3-dropdown-click:hover > .w3-button:first-child{background-color:#ccc;color:#000}
 .w3-dropdown-content{cursor:auto;color:#000;background-color:#fff;display:none;position:absolute;min-width:160px;margin:0;padding:0;z-index:1}
 .w3-check,.w3-radio{width:24px;height:24px;position:relative;top:6px}
-.w3-sidebar{height:100%;width: 309px;background-color:#fff;position:fixed!important;z-index:1;overflow:auto;}
+.w3-sidebar{height:100%;width:10%;background-color:#fff;position:fixed!important;z-index:1;overflow:auto;}
 .w3-bar-block .w3-dropdown-hover,.w3-bar-block .w3-dropdown-click{width:100%}
 .w3-bar-block .w3-dropdown-hover .w3-dropdown-content,.w3-bar-block .w3-dropdown-click .w3-dropdown-content{min-width:100%}
 .w3-bar-block .w3-dropdown-hover .w3-button,.w3-bar-block .w3-dropdown-click .w3-button{width:100%;text-align:left;padding:8px 16px}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

本家サイト [momoirocode.web.fc2.com](http://momoirocode.web.fc2.com/) は `frameset cols="10%,*"` により、左メニューフレームをビューポート幅の **10%** で表示しています。

## 変更内容（mo-code）

`css/w3.css` の `.w3-sidebar` 幅を固定値 `309px` から `10%` に変更し、本家と同じ比率になるようにしました。

## 関連: mostro ビンテージモード

みちくさびゅあーの Astro 版（[iranika/mostro](https://github.com/iranika/mostro)）のビンテージモードでは、左メニューに `min-width: 120px` / `max-width: 200px` が設定されており、広い画面では本家より狭く表示されます。こちらも本家に合わせるには `src/assets/vintage.css` の `.vintage-menu-column` から `min-width` / `max-width` を削除してください（`flex: 0 0 10%` のみ残す）。

## 確認方法

1. `viewer.html` を開き、右上メニューを表示
2. サイドバー幅がウィンドウ幅の約10%になっていることを確認
3. 本家サイトと同じウィンドウ幅で並べて比較
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nika-nln3519.slack.com/archives/C0BHARCUQHE/p1783834574312739?thread_ts=1783834574.312739&cid=C0BHARCUQHE)

<div><a href="https://cursor.com/agents/bc-079cccbe-9fcb-5fc5-b2bd-090d1e6d7742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-079cccbe-9fcb-5fc5-b2bd-090d1e6d7742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

